### PR TITLE
[API][Refine] Make `ActionObserver` a property wrapper

### DIFF
--- a/Sources/ActionKit/NoopAction.swift
+++ b/Sources/ActionKit/NoopAction.swift
@@ -9,16 +9,11 @@ import Combine
 
 public class NoopAction<Value>: Action {
 
-    private let subject = PassthroughSubject<Value, Never>()
-
-    public init() {
-    }
+    public init() {}
 
     public var publisher: AnyPublisher<Value, Never> {
-        subject.eraseToAnyPublisher()
+        Empty().eraseToAnyPublisher()
     }
 
-    public func update(value: Value) {
-        subject.send(value)
-    }
+    public func update(value: Value) {}
 }

--- a/Tests/ActionKitTests/ActionObserverTests.swift
+++ b/Tests/ActionKitTests/ActionObserverTests.swift
@@ -108,3 +108,54 @@ class ActionObserverTests: XCTestCase {
         XCTAssertEqual(observer.value, valueToBeUpdated)
     }
 }
+
+extension ActionObserverTests {
+    
+    struct MyStruct {
+        @ActionObserver var count: Int = 0
+    }
+    
+    func test_actionObserverAsPropertyWrapper_andUpdateValueThroughProperty() throws {
+        let myStruct = MyStruct()
+        
+        // Check the initial value on the property.
+        XCTAssertEqual(myStruct.count, 0)
+        
+        let valueToBeUpdated = 3
+        
+        let updatedReceivedExpectation = XCTestExpectation(description: "Value updated")
+        
+        let action = MyAction(valueToBeUpdated: valueToBeUpdated, expectation: updatedReceivedExpectation)
+        
+        myStruct.$count = action.toAnyAction
+        
+        myStruct.count = valueToBeUpdated
+        
+        wait(for: [updatedReceivedExpectation], timeout: TimeInterval(valueToBeUpdated)+1)
+        
+        // Check the updated value of the property.
+        XCTAssertEqual(myStruct.count, valueToBeUpdated)
+    }
+
+    func test_actionObserverAsPropertyWrapper_andUpdateValueThroughAction() throws {
+        let myStruct = MyStruct()
+
+        // Check the initial value on the property.
+        XCTAssertEqual(myStruct.count, 0)
+
+        let valueToBeUpdated = 3
+
+        let updatedReceivedExpectation = XCTestExpectation(description: "Value updated")
+
+        let action = MyAction(valueToBeUpdated: valueToBeUpdated, expectation: updatedReceivedExpectation)
+
+        myStruct.$count = action.toAnyAction
+
+        myStruct.$count.update(value: valueToBeUpdated)
+
+        wait(for: [updatedReceivedExpectation], timeout: TimeInterval(valueToBeUpdated)+1)
+
+        // Check the updated value of the property.
+        XCTAssertEqual(myStruct.count, valueToBeUpdated)
+    }
+}


### PR DESCRIPTION
This patch updates the `ActionObserver` entity to turn it into a property wrapper, while preserving the existing API compatibility and semantics. This provides an extra level of convenience to users of the entity.