### PR TITLE
[API] Change the projected value type of `ActionObserver` property wrapper

### DIFF
--- a/Sources/ActionKit/ActionObserver.swift
+++ b/Sources/ActionKit/ActionObserver.swift
@@ -11,6 +11,30 @@ import Combine
 @propertyWrapper
 public class ActionObserver<Value> {
 
+    // MARK: Public types
+
+    public class Adapter {
+        public let observer: ActionObserver<Value>
+
+        public var action: AnyAction<Value> {
+            get {
+                observer.action
+            }
+            set {
+                observer.action = newValue
+            }
+        }
+
+        init(observer: ActionObserver<Value>) {
+            self.observer = observer
+            self.action = action
+        }
+
+        public var binding: Binding<Value> {
+            self.observer.binding
+        }
+    }
+
     // MARK: - Private members
 
     private var action: AnyAction<Value> {
@@ -58,12 +82,9 @@ public class ActionObserver<Value> {
         }
     }
 
-    public var projectedValue: AnyAction<Value> {
+    public var projectedValue: Adapter {
         get {
-            self.action
-        }
-        set {
-            self.action = newValue
+            .init(observer: self)
         }
     }
 

--- a/Tests/ActionKitTests/ActionObserverTests.swift
+++ b/Tests/ActionKitTests/ActionObserverTests.swift
@@ -121,6 +121,35 @@ extension ActionObserverTests {
         // Check the updated value of the property.
         XCTAssertEqual(myStruct.count, valueToBeUpdated)
     }
+
+    func test_actionObserverAsPropertyWrapper_andUpdateValueThroughBinding() throws {
+        let myStruct = MyStruct()
+
+        // Check the initial value on the property.
+        XCTAssertEqual(myStruct.count, 0)
+
+        let valueToBeUpdated = 3
+
+        let updatedReceivedExpectation = expectation(description: "Value updated")
+
+        let action = MyAction(
+            valueToBeUpdated: valueToBeUpdated,
+            expectation: updatedReceivedExpectation
+        )
+
+        // Update the action on the struct to be the new action.
+        myStruct.$count.action = action.toAnyAction
+
+        myStruct.$count.binding.wrappedValue = valueToBeUpdated
+
+        wait(
+            for: [updatedReceivedExpectation],
+            timeout: TimeInterval(valueToBeUpdated)+1
+        )
+
+        // Check the updated value of the property.
+        XCTAssertEqual(myStruct.count, valueToBeUpdated)
+    }
 }
 
 fileprivate class MyAction<Value: Equatable>: Action {

--- a/Tests/ActionKitTests/ActionObserverTests.swift
+++ b/Tests/ActionKitTests/ActionObserverTests.swift
@@ -65,64 +65,26 @@ extension ActionObserverTests {
     }
 
     func test_actionObserverAsPropertyWrapper_andUpdateValueThroughProperty() throws {
-        let myStruct = MyStruct()
-
-        // Check the initial value on the property.
-        XCTAssertEqual(myStruct.count, 0)
-
-        let valueToBeUpdated = 3
-
-        let updatedReceivedExpectation = expectation(description: "Value updated")
-
-        let action = MyAction(
-            valueToBeUpdated: valueToBeUpdated,
-            expectation: updatedReceivedExpectation
-        )
-
-        // Update the action on the struct to be the new action.
-        myStruct.$count.action = action.toAnyAction
-        
-        myStruct.count = valueToBeUpdated
-
-        wait(
-            for: [updatedReceivedExpectation],
-            timeout: TimeInterval(valueToBeUpdated)+1
-        )
-
-        // Check the updated value of the property.
-        XCTAssertEqual(myStruct.count, valueToBeUpdated)
+        try _test_actionObserverAsPropertyWrapper { myStruct, valueToBeUpdated in
+            myStruct.count = valueToBeUpdated
+        }
     }
 
     func test_actionObserverAsPropertyWrapper_andUpdateValueThroughAction() throws {
-        let myStruct = MyStruct()
-
-        // Check the initial value on the property.
-        XCTAssertEqual(myStruct.count, 0)
-
-        let valueToBeUpdated = 3
-
-        let updatedReceivedExpectation = expectation(description: "Value updated")
-
-        let action = MyAction(
-            valueToBeUpdated: valueToBeUpdated,
-            expectation: updatedReceivedExpectation
-        )
-
-        // Update the action on the struct to be the new action.
-        myStruct.$count.action = action.toAnyAction
-
-        myStruct.$count.action.update(value: valueToBeUpdated)
-
-        wait(
-            for: [updatedReceivedExpectation],
-            timeout: TimeInterval(valueToBeUpdated)+1
-        )
-
-        // Check the updated value of the property.
-        XCTAssertEqual(myStruct.count, valueToBeUpdated)
+        try _test_actionObserverAsPropertyWrapper { myStruct, valueToBeUpdated in
+            myStruct.$count.action.update(value: valueToBeUpdated)
+        }
     }
 
     func test_actionObserverAsPropertyWrapper_andUpdateValueThroughBinding() throws {
+        try _test_actionObserverAsPropertyWrapper { myStruct, valueToBeUpdated in
+            myStruct.$count.binding.wrappedValue = valueToBeUpdated
+        }
+    }
+
+    private func _test_actionObserverAsPropertyWrapper(
+        withUpdateHandler updateHandler: (MyStruct, Int) -> Void
+    ) throws {
         let myStruct = MyStruct()
 
         // Check the initial value on the property.
@@ -140,7 +102,7 @@ extension ActionObserverTests {
         // Update the action on the struct to be the new action.
         myStruct.$count.action = action.toAnyAction
 
-        myStruct.$count.binding.wrappedValue = valueToBeUpdated
+        updateHandler(myStruct, valueToBeUpdated)
 
         wait(
             for: [updatedReceivedExpectation],

--- a/Tests/ActionKitTests/ActionObserverTests.swift
+++ b/Tests/ActionKitTests/ActionObserverTests.swift
@@ -80,8 +80,8 @@ extension ActionObserverTests {
         )
 
         // Update the action on the struct to be the new action.
-        myStruct.$count = action.toAnyAction
-
+        myStruct.$count.action = action.toAnyAction
+        
         myStruct.count = valueToBeUpdated
 
         wait(
@@ -109,9 +109,9 @@ extension ActionObserverTests {
         )
 
         // Update the action on the struct to be the new action.
-        myStruct.$count = action.toAnyAction
+        myStruct.$count.action = action.toAnyAction
 
-        myStruct.$count.update(value: valueToBeUpdated)
+        myStruct.$count.action.update(value: valueToBeUpdated)
 
         wait(
             for: [updatedReceivedExpectation],


### PR DESCRIPTION
This patch changes the project value type of the `ActionObserver` property wrapper, so that users can still access the binding on the value.